### PR TITLE
Upgrade GNOME runtime to 40

### DIFF
--- a/org.gnome.Mines.json
+++ b/org.gnome.Mines.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Mines",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.36",
+    "runtime-version": "3.38",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-mines",
     "finish-args": [

--- a/org.gnome.Mines.json
+++ b/org.gnome.Mines.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Mines",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.38",
+    "runtime-version": "40",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-mines",
     "finish-args": [


### PR DESCRIPTION
This patch should help to prevent mines from using an unmaintained runtime.